### PR TITLE
chore: configure pre-commit and integrate it into CI lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install clang tools
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
+
+      - name: Install clang-tidy toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang-16 clang-format-16 clang-tidy-16 cmake ninja-build
-
-      - name: clang-format check
-        run: |
-          clang-format-16 --dry-run --Werror $(git ls-files '*.cpp' '*.h')
+          sudo apt-get install -y clang-16 clang-tidy-16 cmake ninja-build
 
       - name: Configure for clang-tidy
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# See https://pre-commit.com for usage and config reference.
+#
+# Local setup:
+#   pip install pre-commit
+#   pre-commit install            # installs the git hook
+#   pre-commit run --all-files    # run all hooks against the whole tree
+#
+# CI mirrors this file via the `lint` job in .github/workflows/ci.yml,
+# so any hook listed here is enforced both locally and in CI. Keep the
+# clang-format mirror's major version aligned with CI's clang-format-16.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-added-large-files
+        args: [--maxkb=512]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.6
+    hooks:
+      - id: clang-format
+        types_or: [c++, c, cuda]

--- a/README.md
+++ b/README.md
@@ -283,9 +283,21 @@ ctorch/
 ## Contributing
 
 1. Fork the repository and create a feature branch off `master`.
-2. Add tests covering the change &mdash; new ops require a parity test.
-3. Ensure `clang-format` and `clang-tidy` are clean.
-4. Open a pull request describing the motivation and approach.
+2. Install the pre-commit hooks once per clone:
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+   This wires `clang-format` and the hygiene checks into every `git commit`.
+3. Add tests covering the change &mdash; new ops require a parity test.
+4. Before opening a PR, run the full hook suite and the clang-tidy gate that CI
+   enforces:
+   ```bash
+   pre-commit run --all-files
+   cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+   clang-tidy-16 -p build $(git ls-files '*.cpp')
+   ```
+5. Open a pull request describing the motivation and approach.
 
 ### Adding a New Op
 


### PR DESCRIPTION
## Summary

Add `.pre-commit-config.yaml` and wire it into the existing CI `lint` job so style/hygiene checks have a single source of truth across local and CI runs.

* New `.pre-commit-config.yaml`:
  * `mirrors-clang-format` pinned to **v16.0.6** to match CI's apt `clang-format-16`.
  * `pre-commit-hooks` v5.0.0: `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-merge-conflict`, `check-added-large-files` (512 KB), `check-case-conflict`, `mixed-line-ending` (LF) — all previously unenforced.
* `lint` job change: `pre-commit run --all-files --show-diff-on-failure` now replaces the standalone `clang-format-16 --dry-run` step. Hook environments are cached on `hashFiles('.pre-commit-config.yaml')` to keep job runtime stable. `clang-tidy-16` stays as a separate step — it needs `compile_commands.json` and is too slow to run per commit.
* README Contributing section now documents the local install (`pip install pre-commit && pre-commit install`) and the pre-PR command (`pre-commit run --all-files`).

## Why CI still gates pre-commit

Local installation is opt-in. Without a CI step, contributors who skip `pre-commit install` would bypass every hygiene check. By having CI run the same `.pre-commit-config.yaml`, hooks are enforced uniformly regardless of whether a contributor installed the local hook.

## Test plan

- [x] Local: `pre-commit run --all-files` — all 8 hooks pass on the current tree.
- [ ] CI: lint job (Ubuntu 24.04) — pre-commit + clang-tidy.
- [ ] CI: build-test matrix (ubuntu-24.04 × {gcc-12, clang-16}, macos-14 × clang) — should be unaffected.