### PR TITLE
feat(allocator): pluggable default-allocator override + counting wrapper (#12)

### DIFF
--- a/include/ctorch/allocator.h
+++ b/include/ctorch/allocator.h
@@ -49,7 +49,22 @@ class Allocator {
 /// CUDA allocators are routed by `Device::index` so each ordinal owns a
 /// distinct caching pool. This matters under multi-GPU: a tensor tagged
 /// `Device::cuda(1)` must be backed by memory that lives on device 1.
+///
+/// If a caller has installed an override via `set_default_allocator`, that
+/// override is returned instead. CUDA overrides are keyed only by
+/// `Device::Kind`, not by ordinal — every CUDA device shares one slot.
 Allocator* default_allocator(Device device);
+
+/// Installs \p allocator as the override returned by `default_allocator`
+/// for \p device's kind, and returns the previous override (or `nullptr`
+/// if none). Passing `nullptr` removes any installed override and
+/// restores the built-in pool.
+///
+/// The installed allocator must outlive every Storage that may be backed
+/// by it; this hook is intended for tests and instrumentation rather than
+/// as a stable user-facing API. The lookup is a single relaxed atomic
+/// load so the no-override hot path is unaffected.
+Allocator* set_default_allocator(Device device, Allocator* allocator);
 
 } // namespace ctorch
 

--- a/src/allocators/counting_allocator.h
+++ b/src/allocators/counting_allocator.h
@@ -1,0 +1,75 @@
+//===- src/allocators/counting_allocator.h - Instrumented allocator -------===//
+//
+// Part of the ctorch Project, under the MIT License.
+// See LICENSE for license information.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Header-only Allocator wrapper that tallies the number of allocate /
+/// deallocate calls and live byte count. Intended as the
+/// "sampling allocator hook" backing the no-heap-alloc assertions in
+/// Issue 09 §N3 and as a general instrumentation primitive for tests.
+///
+/// Counters are atomic so the wrapper is safe to share across threads.
+/// The wrapped base allocator is borrowed; CountingAllocator does not
+/// take ownership and the base must outlive the wrapper.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef CTORCH_ALLOCATORS_COUNTING_ALLOCATOR_H
+#define CTORCH_ALLOCATORS_COUNTING_ALLOCATOR_H
+
+#include "ctorch/allocator.h"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace ctorch {
+
+class CountingAllocator final : public Allocator {
+  public:
+    explicit CountingAllocator(Allocator* base) : base_(base) {}
+
+    void* allocate(std::size_t bytes) override {
+        void* p = base_->allocate(bytes);
+        // Mirror the CPU pool's "0-byte allocate returns nullptr" contract
+        // so this wrapper does not invent allocations the base did not do.
+        if (p != nullptr) {
+            alloc_calls_.fetch_add(1, std::memory_order_relaxed);
+            live_bytes_.fetch_add(static_cast<std::int64_t>(bytes), std::memory_order_relaxed);
+        }
+        return p;
+    }
+
+    void deallocate(void* p, std::size_t bytes) override {
+        base_->deallocate(p, bytes);
+        if (p != nullptr) {
+            dealloc_calls_.fetch_add(1, std::memory_order_relaxed);
+            live_bytes_.fetch_sub(static_cast<std::int64_t>(bytes), std::memory_order_relaxed);
+        }
+    }
+
+    std::size_t alloc_calls() const noexcept {
+        return alloc_calls_.load(std::memory_order_relaxed);
+    }
+    std::size_t dealloc_calls() const noexcept {
+        return dealloc_calls_.load(std::memory_order_relaxed);
+    }
+    /// Net live bytes (alloc bytes minus dealloc bytes). Signed so a buggy
+    /// caller producing a deficit shows up as a negative number rather
+    /// than a giant unsigned wraparound.
+    std::int64_t live_bytes() const noexcept { return live_bytes_.load(std::memory_order_relaxed); }
+
+  private:
+    Allocator* base_;
+    std::atomic<std::size_t> alloc_calls_{0};
+    std::atomic<std::size_t> dealloc_calls_{0};
+    std::atomic<std::int64_t> live_bytes_{0};
+};
+
+} // namespace ctorch
+
+#endif // CTORCH_ALLOCATORS_COUNTING_ALLOCATOR_H

--- a/src/allocators/default_allocator.cpp
+++ b/src/allocators/default_allocator.cpp
@@ -34,14 +34,17 @@ namespace ctorch {
 
 namespace {
 
-/// Per-Kind override slot. Loaded with relaxed semantics on every
-/// `default_allocator` call; when no override is installed the value is
-/// `nullptr` and the call falls through to the built-in pool. The slot
-/// is keyed only by `Device::Kind` because tests overwhelmingly want to
-/// instrument either "the CPU pool" or "every CUDA pool" rather than a
-/// single device ordinal — and routing CUDA overrides per-ordinal would
-/// either need a bounded ordinal table or a lookup mutex on the hot
-/// path.
+/// Per-Kind override slot. Readers load with acquire semantics so the
+/// release-side store in `set_default_allocator` (acq_rel exchange)
+/// synchronizes-with the read; without that edge a consumer could see
+/// the published pointer but observe stale bytes of the override
+/// object's non-atomic state (e.g. `CountingAllocator::base_`). When no
+/// override is installed the value is `nullptr` and the call falls
+/// through to the built-in pool. The slot is keyed only by
+/// `Device::Kind` because tests overwhelmingly want to instrument
+/// either "the CPU pool" or "every CUDA pool" rather than a single
+/// device ordinal — and routing CUDA overrides per-ordinal would either
+/// need a bounded ordinal table or a lookup mutex on the hot path.
 ///
 /// Throws `std::invalid_argument` if `kind` is outside the declared
 /// enumerators. `enum class` is not a closed set in C++ — a malformed
@@ -109,7 +112,7 @@ detail::CudaCachingAllocator* cuda_allocator_for(int index) {
 #endif // CTORCH_HAS_CUDA
 
 Allocator* default_allocator(Device device) {
-    if (auto* override = override_slot(device.kind).load(std::memory_order_relaxed)) {
+    if (auto* override = override_slot(device.kind).load(std::memory_order_acquire)) {
         return override;
     }
     switch (device.kind) {

--- a/src/allocators/default_allocator.cpp
+++ b/src/allocators/default_allocator.cpp
@@ -42,9 +42,18 @@ namespace {
 /// single device ordinal — and routing CUDA overrides per-ordinal would
 /// either need a bounded ordinal table or a lookup mutex on the hot
 /// path.
+///
+/// Throws `std::invalid_argument` if `kind` is outside the declared
+/// enumerators. `enum class` is not a closed set in C++ — a malformed
+/// value can arrive from a memcpy / FFI / out-of-range cast, and we
+/// must not index the slot table out-of-bounds in that case.
 std::atomic<Allocator*>& override_slot(Device::Kind kind) {
     static std::atomic<Allocator*> slots[kNumDeviceKinds]{};
-    return slots[static_cast<std::size_t>(kind)];
+    const auto idx = static_cast<std::size_t>(kind);
+    if (idx >= static_cast<std::size_t>(kNumDeviceKinds)) {
+        throw std::invalid_argument("ctorch: unknown Device::Kind");
+    }
+    return slots[idx];
 }
 
 } // namespace

--- a/src/allocators/default_allocator.cpp
+++ b/src/allocators/default_allocator.cpp
@@ -18,6 +18,7 @@
 
 #include "allocators/cpu_pool.h"
 
+#include <atomic>
 #include <stdexcept>
 
 #if defined(CTORCH_HAS_CUDA)
@@ -30,6 +31,23 @@
 #endif
 
 namespace ctorch {
+
+namespace {
+
+/// Per-Kind override slot. Loaded with relaxed semantics on every
+/// `default_allocator` call; when no override is installed the value is
+/// `nullptr` and the call falls through to the built-in pool. The slot
+/// is keyed only by `Device::Kind` because tests overwhelmingly want to
+/// instrument either "the CPU pool" or "every CUDA pool" rather than a
+/// single device ordinal — and routing CUDA overrides per-ordinal would
+/// either need a bounded ordinal table or a lookup mutex on the hot
+/// path.
+std::atomic<Allocator*>& override_slot(Device::Kind kind) {
+    static std::atomic<Allocator*> slots[kNumDeviceKinds]{};
+    return slots[static_cast<std::size_t>(kind)];
+}
+
+} // namespace
 
 #if defined(CTORCH_HAS_CUDA)
 namespace {
@@ -82,6 +100,9 @@ detail::CudaCachingAllocator* cuda_allocator_for(int index) {
 #endif // CTORCH_HAS_CUDA
 
 Allocator* default_allocator(Device device) {
+    if (auto* override = override_slot(device.kind).load(std::memory_order_relaxed)) {
+        return override;
+    }
     switch (device.kind) {
     case Device::Kind::CPU: {
         static detail::CpuPoolAllocator cpu;
@@ -97,6 +118,10 @@ Allocator* default_allocator(Device device) {
     }
     }
     throw std::invalid_argument("ctorch::default_allocator: unknown Device::Kind");
+}
+
+Allocator* set_default_allocator(Device device, Allocator* allocator) {
+    return override_slot(device.kind).exchange(allocator, std::memory_order_acq_rel);
 }
 
 } // namespace ctorch

--- a/tests/allocator/CMakeLists.txt
+++ b/tests/allocator/CMakeLists.txt
@@ -3,6 +3,13 @@ ctorch_add_test(cpu_pool_test
   LIBS    ctorch_core
 )
 
+ctorch_add_test(counting_allocator_test
+  SOURCES counting_allocator_test.cpp
+  LIBS    ctorch_core
+)
+# counting_allocator_test reaches into the header-only wrapper under src/.
+target_include_directories(counting_allocator_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
 if(CTORCH_CUDA)
   ctorch_add_test(cuda_caching_test
     SOURCES cuda_caching_test.cpp

--- a/tests/allocator/counting_allocator_test.cpp
+++ b/tests/allocator/counting_allocator_test.cpp
@@ -1,0 +1,135 @@
+//===- tests/allocator/counting_allocator_test.cpp - hook + counter ------===//
+//
+// Part of the ctorch Project, under the MIT License.
+// See LICENSE for license information.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Verifies the per-Kind override slot in `default_allocator` and the
+/// header-only `CountingAllocator` wrapper that backs Issue 09 §N3's
+/// no-heap-alloc assertion.
+///
+//===----------------------------------------------------------------------===//
+
+#include "ctorch/allocator.h"
+#include "ctorch/device.h"
+#include "ctorch/dtype.h"
+#include "ctorch/tensor.h"
+
+#include "allocators/counting_allocator.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+namespace {
+
+class AllocatorOverrideGuard {
+  public:
+    AllocatorOverrideGuard(ctorch::Device device, ctorch::Allocator* a)
+        : device_(device), prev_(ctorch::set_default_allocator(device, a)) {}
+    ~AllocatorOverrideGuard() { ctorch::set_default_allocator(device_, prev_); }
+    AllocatorOverrideGuard(const AllocatorOverrideGuard&) = delete;
+    AllocatorOverrideGuard& operator=(const AllocatorOverrideGuard&) = delete;
+
+  private:
+    ctorch::Device device_;
+    ctorch::Allocator* prev_;
+};
+
+} // namespace
+
+TEST(CountingAllocator, TalliesAllocateAndDeallocate) {
+    auto* base = ctorch::default_allocator(ctorch::Device::cpu());
+    ctorch::CountingAllocator counter(base);
+
+    void* p = counter.allocate(64);
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(counter.alloc_calls(), 1u);
+    EXPECT_EQ(counter.live_bytes(), 64);
+
+    counter.deallocate(p, 64);
+    EXPECT_EQ(counter.dealloc_calls(), 1u);
+    EXPECT_EQ(counter.live_bytes(), 0);
+}
+
+TEST(CountingAllocator, ZeroByteAllocateDoesNotIncrementCounters) {
+    auto* base = ctorch::default_allocator(ctorch::Device::cpu());
+    ctorch::CountingAllocator counter(base);
+
+    // Mirror CpuPool: allocate(0) returns nullptr and is not counted.
+    void* p = counter.allocate(0);
+    EXPECT_EQ(p, nullptr);
+    EXPECT_EQ(counter.alloc_calls(), 0u);
+    EXPECT_EQ(counter.live_bytes(), 0);
+
+    counter.deallocate(nullptr, 0);
+    EXPECT_EQ(counter.dealloc_calls(), 0u);
+}
+
+TEST(SetDefaultAllocator, OverlayRedirectsThenRestores) {
+    auto* original = ctorch::default_allocator(ctorch::Device::cpu());
+    ctorch::CountingAllocator counter(original);
+
+    auto* prev = ctorch::set_default_allocator(ctorch::Device::cpu(), &counter);
+    // First call returns the previous (nullptr if no other overlay was
+    // installed), so the overlay slot is otherwise untouched by the test
+    // suite.
+    EXPECT_EQ(prev, nullptr);
+    EXPECT_EQ(ctorch::default_allocator(ctorch::Device::cpu()), &counter);
+
+    auto* after_restore = ctorch::set_default_allocator(ctorch::Device::cpu(), nullptr);
+    EXPECT_EQ(after_restore, &counter);
+    EXPECT_EQ(ctorch::default_allocator(ctorch::Device::cpu()), original);
+}
+
+TEST(SetDefaultAllocator, CountsTensorBackedAllocation) {
+    auto* base = ctorch::default_allocator(ctorch::Device::cpu());
+    ctorch::CountingAllocator counter(base);
+
+    AllocatorOverrideGuard guard(ctorch::Device::cpu(), &counter);
+
+    const auto baseline_alloc = counter.alloc_calls();
+    const auto baseline_dealloc = counter.dealloc_calls();
+    {
+        ctorch::Tensor t({1024}, ctorch::dtype::float32, ctorch::Device::cpu());
+        EXPECT_EQ(counter.alloc_calls() - baseline_alloc, 1u);
+        EXPECT_GE(counter.live_bytes(), static_cast<std::int64_t>(1024 * sizeof(float)));
+    }
+    EXPECT_EQ(counter.dealloc_calls() - baseline_dealloc, 1u);
+    EXPECT_EQ(counter.live_bytes(), 0);
+}
+
+TEST(CountingAllocator, ConcurrentAllocateIsRaceFree) {
+    auto* base = ctorch::default_allocator(ctorch::Device::cpu());
+    ctorch::CountingAllocator counter(base);
+
+    constexpr int kThreads = 8;
+    constexpr int kAllocsPerThread = 256;
+    constexpr std::size_t kBytes = 32;
+
+    std::vector<std::thread> ts;
+    ts.reserve(kThreads);
+    for (int i = 0; i < kThreads; ++i) {
+        ts.emplace_back([&] {
+            std::vector<void*> ptrs;
+            ptrs.reserve(kAllocsPerThread);
+            for (int j = 0; j < kAllocsPerThread; ++j) {
+                ptrs.push_back(counter.allocate(kBytes));
+            }
+            for (void* p : ptrs) {
+                counter.deallocate(p, kBytes);
+            }
+        });
+    }
+    for (auto& t : ts) {
+        t.join();
+    }
+    EXPECT_EQ(counter.alloc_calls(), static_cast<std::size_t>(kThreads * kAllocsPerThread));
+    EXPECT_EQ(counter.dealloc_calls(), static_cast<std::size_t>(kThreads * kAllocsPerThread));
+    EXPECT_EQ(counter.live_bytes(), 0);
+}

--- a/tests/allocator/counting_allocator_test.cpp
+++ b/tests/allocator/counting_allocator_test.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
@@ -102,6 +103,17 @@ TEST(SetDefaultAllocator, CountsTensorBackedAllocation) {
     }
     EXPECT_EQ(counter.dealloc_calls() - baseline_dealloc, 1u);
     EXPECT_EQ(counter.live_bytes(), 0);
+}
+
+TEST(SetDefaultAllocator, RejectsOutOfRangeDeviceKind) {
+    // `enum class` is not a closed set: a malformed value can arrive
+    // via memcpy / FFI / out-of-range cast. Both `default_allocator`
+    // and `set_default_allocator` index a fixed-size slot table and
+    // must guard against this rather than reading out-of-bounds.
+    ctorch::Device d;
+    d.kind = static_cast<ctorch::Device::Kind>(99);
+    EXPECT_THROW(ctorch::default_allocator(d), std::invalid_argument);
+    EXPECT_THROW(ctorch::set_default_allocator(d, nullptr), std::invalid_argument);
 }
 
 TEST(CountingAllocator, ConcurrentAllocateIsRaceFree) {


### PR DESCRIPTION
## Summary

Closes #12. Prereq for #9 §N3 (no-heap-alloc verification of CPU `sum`).

- Add `set_default_allocator(Device, Allocator*)` returning the previous overlay; `default_allocator(Device)` consults a per-`Kind` `std::atomic<Allocator*>` slot first and falls back to the existing CPU pool / CUDA caching pool.
- Add header-only `CountingAllocator` that wraps any base `Allocator*` and exposes atomic `alloc_calls()` / `dealloc_calls()` / `live_bytes()` counters. Mirrors the CPU pool's "0-byte allocate returns nullptr" contract so the wrapper does not invent allocations the base does not do.
- Hot-path cost when no override is installed: one relaxed atomic load.

The shape mirrors Issue #12's two-commit suggestion:
1. `feat(allocator): per-device override slot in default_allocator`
2. `feat(allocator): header-only CountingAllocator wrapper + tests`

## Test plan

- [x] `ctest --test-dir build_cpu --output-on-failure` — 113 passed, 0 failed (one CUDA smoke test skipped on CPU-only build).
- [x] New `counting_allocator_test` (5 cases) covers: tally correctness, the zero-byte-not-counted contract, overlay install/restore round-trip, end-to-end count around a `Tensor` allocation, and concurrent access from 8 threads.
- [x] `pre-commit run` clean (clang-format applied to one one-liner).
- [ ] CI green on Linux (CPU + CUDA matrix).