### PR TITLE
chore: ignore build_*/ output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_*/
 .cache/
 *.DS_Store
 .idea/


### PR DESCRIPTION
## Summary

Adds `build_*/` to `.gitignore` so common per-config out-of-source build dirs (e.g. `build_cpu/`, `build_cuda/`, `build_debug/`) don't show up as untracked. The existing `build/` line covers only the default name.

Surfaced by the Codex local review on PR #13 as a P2 hygiene note.

## Test plan
- [x] `git status` no longer shows `build_cpu/` after running `cmake -S . -B build_cpu …`
- [x] `build/` and `cmake-build-*/` patterns still match as before